### PR TITLE
Update to Rocq 9.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean: Makefile.coq
 	rm -f tictactoe.{ml,mli}
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq
+	rocq makefile -f _CoqProject -o Makefile.coq
 
 run:
 	ocaml tictactoe.ml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Rationale
 
-This repository contains functions and proofs about game trees in Rocq, implemented as [rose trees](https://en.wikipedia.org/wiki/Rose_tree). We provide two different flavors of game trees, inductive and coinductive game trees. Inductive game trees are finite by construction, but it is difficult to populate a tree from an initial value and a function that gives the next steps. We have to prove that the population (anamorphism or unfolding of a rose tree) terminates. Coinductive game trees can be infinite or finite. Populating a coinductive tree is easy since we do not have to prove termination, but we need bisimulation to reason about them.
+This repository contains functions and proofs about game trees in [Rocq](https://rocq-prover.org/), implemented as [rose trees](https://en.wikipedia.org/wiki/Rose_tree). We provide two different flavors of game trees, inductive and coinductive game trees. Inductive game trees are finite by construction, but it is difficult to populate a tree from an initial value and a function that gives the next steps. We have to prove that the population (anamorphism or unfolding of a rose tree) terminates. Coinductive game trees can be infinite or finite. Populating a coinductive tree is easy since we do not have to prove termination, but we need bisimulation to reason about them.
 
 ## Quick start
 
@@ -24,9 +24,9 @@ To showcase our library, we provide an example: a tic-tac-toe game for which we 
 
 ## Building
 
-You have to have the `coq-released` registry of `opam`. You can obtain it by running `opam repo add coq-released https://coq.inria.fr/opam/released` if you do not already have it.
+You have to have the `rocq-released` registry of `opam`. You can obtain it by running `opam repo add rocq-released https://rocq-prover.org/opam/released` if you do not already have it.
 
-To install the dependencies, run `opam install . --deps-only`. The project certainly builds with Coq 8.20.1, so we hard-coded it for reproducibility.
+To install the dependencies, run `opam install . --deps-only`. The project builds with Rocq 9.0.0 or higher.
 
 To build the project use `make`. After that, you can optionally run the tic-tac-toe game with `make run`.
 

--- a/rocq-game-trees.opam
+++ b/rocq-game-trees.opam
@@ -1,11 +1,12 @@
 opam-version: "2.0"
 synopsis: "Definitions and functions about game trees in Rocq"
-homepage: "tbd"
+homepage: "https://github.com/bloomberg/game-trees"
 license: "Apache-2.0"
-bug-reports: "tbd/issues"
+bug-reports: "https://github.com/bloomberg/game-trees/issues"
 depends: [
   "ocaml"
-  "coq" {= "8.20.1"}
+  "rocq-prover" {>= "9.0.0"}
+  "coq"
   "coq-ext-lib" {>= "0.13"}
   "coq-simple-io" {>= "1.11.0"}
 ]

--- a/theories/Cotrees.v
+++ b/theories/Cotrees.v
@@ -1,13 +1,13 @@
 (* Copyright 2025 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the Apache 2.0 license. *)
 
-Require Import List.
-Require Import Coq.Classes.Morphisms.
-Require Import Coq.Classes.RelationClasses.
-Require Import Coq.Relations.Relation_Definitions.
-Require Import Coq.Relations.Relation_Operators.
-Require Import Coq.Relations.Operators_Properties.
-Require Import Coq.Program.Equality.
+Require Import Corelib.Classes.Morphisms.
+Require Import Corelib.Classes.RelationClasses.
+Require Import Corelib.Relations.Relation_Definitions.
+From Stdlib Require Import List.
+From Stdlib Require Import Relations.Relation_Operators.
+From Stdlib Require Import Relations.Operators_Properties.
+From Stdlib Require Import Program.Equality.
 
 Require Import GameTrees.Helpers.
 Require Import GameTrees.Trees.

--- a/theories/Eval.v
+++ b/theories/Eval.v
@@ -1,12 +1,12 @@
 (* Copyright 2025 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the Apache 2.0 license. *)
 
-Require Import Streams.
-Require Import List.
-Require Import Coq.Classes.RelationClasses.
-Require Import Coq.Logic.Decidable.
-Require Import Coq.Relations.Relation_Definitions.
-Require Import Coq.Relations.Relation_Operators.
+Require Import Corelib.Classes.RelationClasses.
+Require Import Corelib.Relations.Relation_Definitions.
+From Stdlib Require Import Streams.
+From Stdlib Require Import List.
+From Stdlib Require Import Logic.Decidable.
+From Stdlib Require Import Relations.Relation_Operators.
 
 Require Import ExtLib.Core.RelDec.
 

--- a/theories/Helpers.v
+++ b/theories/Helpers.v
@@ -1,9 +1,8 @@
 (* Copyright 2025 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the Apache 2.0 license. *)
 
-Require Import List.
-Require Import Coq.Relations.Relation_Definitions.
-Require Import Coq.Relations.Relation_Operators.
+Require Import Corelib.Relations.Relation_Definitions.
+From Stdlib Require Import List.
 
 Import ListNotations.
 

--- a/theories/Relations.v
+++ b/theories/Relations.v
@@ -1,11 +1,9 @@
 (* Copyright 2025 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the Apache 2.0 license. *)
 
-Require Import List.
-Require Import Coq.Arith.Compare_dec.
-Require Import Coq.Classes.RelationClasses.
-Require Import Coq.Relations.Relation_Definitions.
-Require Import Coq.Relations.Relation_Operators.
+Require Import Corelib.Classes.RelationClasses.
+Require Import Corelib.Relations.Relation_Definitions.
+From Stdlib Require Import List.
 
 Require Import ExtLib.Core.RelDec.
 

--- a/theories/TicTacToe.v
+++ b/theories/TicTacToe.v
@@ -1,12 +1,13 @@
 (* Copyright 2025 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the Apache 2.0 license. *)
 
-Require Import List PeanoNat.
-Require Import Psatz.
-Require Import Coq.Classes.RelationClasses.
-Require Import Coq.Program.Basics.
-Require Import Coq.Program.Equality.
-Require Import Coq.Wellfounded.Inverse_Image.
+Require Import Corelib.Classes.RelationClasses.
+Require Import Corelib.Program.Basics.
+From Stdlib Require Import List.
+From Stdlib Require Import PeanoNat.
+From Stdlib Require Import Psatz.
+From Stdlib Require Import Program.Equality.
+From Stdlib Require Import Wellfounded.Inverse_Image.
 
 Import ListNotations.
 
@@ -14,7 +15,6 @@ Require Import GameTrees.Helpers.
 Require Import GameTrees.Relations.
 Require Import GameTrees.Trees.
 Require Import GameTrees.Eval.
-Require GameTrees.Cotrees.
 
 Inductive player : Type := x | o.
 
@@ -284,6 +284,8 @@ Definition complete_tree : tree game :=
 
 (* True theorem but it takes too long to run! *)
 (*
+Require GameTrees.Cotrees.
+
 Theorem ttt_is_finite : Cotrees.finite_game ttt_next ttt_init.
 Proof.
   exists 10; vm_compute; reflexivity.
@@ -294,11 +296,10 @@ Definition complete_tree' : tree game :=
   Cotrees.tree_of_cotree ttt_is_finite.1 (Cotrees.unfold_cotree ttt_next ttt_init).
 *)
 
-Require Import String.
+From Stdlib Require Import String.
 #[local] Open Scope string_scope.
 
 Require Import SimpleIO.SimpleIO.
-Require Import Coq.Sorting.Mergesort.
 Require Import ExtLib.Core.RelDec.
 Import IO.Notations.
 
@@ -380,9 +381,10 @@ Definition play (t : tree (game * nat)) : IO (tree (game * nat)) :=
 Definition unsafe_main : io_unit :=
   IO.unsafe_run (IO.loop play scored_tree).
 
-Require Import Coq.extraction.ExtrOcamlBasic.
-Require Import Coq.extraction.ExtrOcamlNatInt.
-Require Import Coq.extraction.ExtrOcamlString.
+Require Import Corelib.extraction.ExtrOcamlBasic.
+Require Import Corelib.extraction.ExtrOcamlBasic.
+From Stdlib Require Import extraction.ExtrOcamlString.
+From Stdlib Require Import extraction.ExtrOcamlNatInt.
 
 Module Extraction.
 Extract Inductive sigT => "( * )" [""].

--- a/theories/Trees.v
+++ b/theories/Trees.v
@@ -1,12 +1,12 @@
 (* Copyright 2025 Bloomberg Finance L.P. *)
 (* Distributed under the terms of the Apache 2.0 license. *)
 
-Require Import List.
-Require Import Coq.Relations.Relation_Definitions.
-Require Import Coq.Relations.Relation_Operators.
-Require Import Coq.Relations.Operators_Properties.
-Require Import Coq.Program.Wf.
-Require Import Coq.Program.Equality.
+Require Import Corelib.Program.Wf.
+Require Import Corelib.Relations.Relation_Definitions.
+From Stdlib Require Import List.
+From Stdlib Require Import Relations.Relation_Operators.
+From Stdlib Require Import Relations.Operators_Properties.
+From Stdlib Require Import Program.Equality.
 
 Require Import GameTrees.Helpers.
 Require Import GameTrees.Relations.


### PR DESCRIPTION
Updating from Coq 8.20.1 to Rocq 9.0.0, to adapt to the renaming of Coq to Rocq.
